### PR TITLE
Downgrade ActiveSupport dependency version from 5 to 4

### DIFF
--- a/name_drop.gemspec
+++ b/name_drop.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'rest-client', '~> 2.0'
-  spec.add_runtime_dependency 'activesupport', '~> 5.0'
+  spec.add_runtime_dependency 'activesupport', '~> 4.0'
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
@@ -34,7 +34,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
   spec.add_development_dependency 'simplecov', '~> 0.12'
-  spec.add_development_dependency 'rest-client', '~> 2.0'
-  spec.add_development_dependency 'activesupport', '~> 5.0'
-
 end


### PR DESCRIPTION
@prpetten Unless we have any specific dependency on ActiveSupport 5, it would be nice to loosen the restriction so that applications using Rails 4 can use this library too.

Thoughts?
