### PR TITLE
Renaming error attribute response to detail

### DIFF
--- a/lib/name_drop/error.rb
+++ b/lib/name_drop/error.rb
@@ -1,9 +1,9 @@
 module NameDrop
   class Error < StandardError
-    attr_reader :response
+    attr_reader :detail
 
-    def initialize(msg, response)
-      @response = response
+    def initialize(msg, detail)
+      @detail = detail
       super msg
     end
   end

--- a/spec/name_drop/error_spec.rb
+++ b/spec/name_drop/error_spec.rb
@@ -9,7 +9,7 @@ describe NameDrop::Error do
 
     it 'sets the response' do
       error = NameDrop::Error.new('You will take me', 'to Jobba now')
-      expect(error.response).to eq('to Jobba now')
+      expect(error.detail).to eq('to Jobba now')
     end
   end
 end


### PR DESCRIPTION
Feel like this is a better generic name for what we're doing, and it makes inheriting from `NameDrop::Error` more friendly in terms of what the error stores.
