### PR TITLE
Adding Version, Dependencies, Docs badges, removing issues badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
+[![Gem Version](https://img.shields.io/gem/v/name_drop.svg?style=flat)](https://rubygems.org/gems/name_drop)
 [![Build Status](https://travis-ci.org/500friends/name_drop.svg?branch=master)](https://travis-ci.org/500friends/name_drop)
 [![Test Coverage](https://codeclimate.com/github/500friends/name_drop/badges/coverage.svg)](https://codeclimate.com/github/500friends/name_drop/coverage)
 [![Code Climate](https://codeclimate.com/github/500friends/name_drop/badges/gpa.svg)](https://codeclimate.com/github/500friends/name_drop)
-[![Issue Count](https://codeclimate.com/github/500friends/name_drop/badges/issue_count.svg)](https://codeclimate.com/github/500friends/name_drop)
-
+[![Dependency Status](https://gemnasium.com/badges/github.com/500friends/name_drop.svg)](https://gemnasium.com/github.com/500friends/name_drop)
+[![Inline docs](http://inch-ci.org/github/500friends/name_drop.svg?branch=master)](http://inch-ci.org/github/500friends/name_drop)
 
 # NameDrop
 

--- a/name_drop.gemspec
+++ b/name_drop.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rest-client', '~> 2.0'
   spec.add_runtime_dependency 'activesupport', '>= 3.2'
   spec.add_development_dependency 'bundler', '~> 1.12'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 11.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-nc', '~> 0.3'
   spec.add_development_dependency 'guard', '~> 2.14'


### PR DESCRIPTION
Looking across all of the popular gems, these were the only badges we didn't have.  Also most gems that had a code climate badge, didn't also include their issues badge, just the score.
