### PR TITLE
Thread safe eagerloading

### DIFF
--- a/lib/name_drop.rb
+++ b/lib/name_drop.rb
@@ -1,14 +1,37 @@
-require 'name_drop/version'
+require 'active_support'
 
-require 'name_drop/configuration'
-require 'name_drop/client'
-require 'name_drop/error'
+module NameDrop
+  extend ActiveSupport::Autoload
 
-require 'name_drop/resources/base'
-require 'name_drop/resources/base_factory'
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
 
-require 'name_drop/resources/alert'
-require 'name_drop/resources/mention'
-require 'name_drop/resources/share'
+    def configuration=(config)
+      @configuration = config
+    end
 
+    def configure
+      yield configuration
+    end
+  end
 
+  eager_autoload do
+    autoload :Configuration
+    autoload :Client
+    autoload :Error
+  end
+
+  module Resources
+    extend ActiveSupport::Autoload
+
+    eager_autoload do
+      autoload :Base
+      autoload :BaseFactory
+      autoload :Alert
+      autoload :Mention
+      autoload :Share
+    end
+  end
+end

--- a/lib/name_drop.rb
+++ b/lib/name_drop.rb
@@ -1,4 +1,4 @@
-require 'active_support'
+require 'active_support/dependencies/autoload'
 
 module NameDrop
   extend ActiveSupport::Autoload

--- a/lib/name_drop.rb
+++ b/lib/name_drop.rb
@@ -37,4 +37,11 @@ module NameDrop
       autoload :Share
     end
   end
+
+  def self.eager_load!
+    super
+    NameDrop::Resources.eager_load!
+  end
 end
+
+require 'name_drop/railtie' if defined?(Rails)

--- a/lib/name_drop/configuration.rb
+++ b/lib/name_drop/configuration.rb
@@ -7,19 +7,4 @@ module NameDrop
       @access_token = 'NotARealAccessToken'
     end
   end
-
-  class << self
-
-    def configuration
-      @configuration ||= Configuration.new
-    end
-
-    def configuration=(config)
-      @configuration = config
-    end
-
-    def configure
-      yield(configuration)
-    end
-  end
 end

--- a/lib/name_drop/railtie.rb
+++ b/lib/name_drop/railtie.rb
@@ -1,0 +1,7 @@
+require 'rails/railtie'
+
+module NameDrop
+  class Railtie < Rails::Railtie
+    config.eager_load_namespaces << NameDrop
+  end
+end


### PR DESCRIPTION
This replaces the `require` statements with thread-safe eager autoloading provided by ActiveSupport.
