### PR TITLE
[WIP] Associations DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,25 @@ all_alerts = client.alerts.all
 Fetching single object
 
 ```ruby
-alert = client.alert.find(mention_alert_id)
+alert = client.alerts.find(mention_alert_id)
+```
+
+Fetching nested objects
+
+```ruby
+mentions = alerts.mentions.all
 ```
 
 Create object
 ```ruby
-alert = client.alert.build(new_attributes_hash)
+alert = client.alerts.build(new_attributes_hash)
 alert.save
 ```
 
 Update object
 
 ```ruby
-alert = client.alert.find(mention_alert_id)
+alert = client.alerts.find(mention_alert_id)
 alert.attributes = updated_attributes_hash
 alert.save
 ```
@@ -78,7 +84,7 @@ alert.save
 Destroy object
 
 ```ruby
-shares = client.share.all(alert_id: 1)
+shares = alert.shares
 shares.each do |share|
   share.destroy
 end

--- a/lib/name_drop.rb
+++ b/lib/name_drop.rb
@@ -1,16 +1,63 @@
 require 'active_support/inflector'
+require 'active_support/concern'
 require 'active_support/core_ext/object'
 require 'active_support/core_ext/hash/indifferent_access'
 
-require 'name_drop/version'
+module NameDrop
 
-require 'name_drop/configuration'
-require 'name_drop/client'
-require 'name_drop/error'
+  class << self
+    def resource_class(resource)
+      NameDrop::Resources.const_get(resource.to_s.classify)
+    end
 
-require 'name_drop/resources/base'
-require 'name_drop/resources/base_factory'
+    def configuration
+      @configuration ||= Configuration.new
+    end
 
-require 'name_drop/resources/alert'
-require 'name_drop/resources/mention'
-require 'name_drop/resources/share'
+    def configuration=(config)
+      @configuration = config
+    end
+
+    def configure
+      yield(configuration)
+    end
+  end
+
+  autoload :Version,       'name_drop/version'
+  autoload :Configuration, 'name_drop/configuration'
+  autoload :Client,        'name_drop/client'
+  autoload :Error,         'name_drop/error'
+
+  module Resources
+    autoload :Base,        'name_drop/resources/base'
+    autoload :BaseFactory, 'name_drop/resources/base_factory'
+
+    autoload :Alert,       'name_drop/resources/alert'
+    autoload :Mention,     'name_drop/resources/mention'
+    autoload :Share,       'name_drop/resources/share'
+  end
+
+  module Associations
+    autoload :Dsl,         'name_drop/associations/dsl'
+    autoload :BelongsTo,   'name_drop/associations/belongs_to'
+  end
+end
+
+
+
+# require 'name_drop/version'
+# require 'name_drop/configuration'
+# require 'name_drop/client'
+# require 'name_drop/error'
+#
+# require 'name_drop/resources/base'
+# require 'name_drop/resources/base_factory'
+#
+# require 'name_drop/resources/alert'
+# require 'name_drop/resources/mention'
+# require 'name_drop/resources/share'
+#
+# require 'name_drop/associations/dsl'
+# require 'name_drop/associations/belongs_to'
+
+

--- a/lib/name_drop.rb
+++ b/lib/name_drop.rb
@@ -45,6 +45,8 @@ module NameDrop
     eager_autoload do
       autoload :Dsl
       autoload :BelongsTo
+      autoload :HasMany
+      autoload :HasManyProxy
     end
   end
 

--- a/lib/name_drop.rb
+++ b/lib/name_drop.rb
@@ -1,14 +1,37 @@
-require 'name_drop/version'
+require 'active_support'
 
-require 'name_drop/configuration'
-require 'name_drop/client'
-require 'name_drop/error'
+module NameDrop
+  extend ActiveSupport::Autoload
 
-require 'name_drop/resources/base'
-require 'name_drop/resources/base_factory'
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
 
-require 'name_drop/resources/alert'
-require 'name_drop/resources/mention'
-require 'name_drop/resources/share'
+    def configuration=(config)
+      @configuration = config
+    end
 
+    def configure
+      yield configuration
+    end
+  end
 
+  eager_autoload do
+    autoload :Configuration
+    autoload :Client
+    autoload :Error
+  end
+
+  module Resources
+    extend ActiveSupport::Autoload
+
+    eager_autoload do
+      autoload :Base
+      autoload :BaseFactory
+      autoload :Alert
+      autoload :Mention
+      autoload :Share
+    end
+  end
+end

--- a/lib/name_drop.rb
+++ b/lib/name_drop.rb
@@ -1,4 +1,4 @@
-require 'active_support'
+require 'active_support/dependencies/autoload'
 
 module NameDrop
   extend ActiveSupport::Autoload

--- a/lib/name_drop.rb
+++ b/lib/name_drop.rb
@@ -37,4 +37,11 @@ module NameDrop
       autoload :Share
     end
   end
+
+  def self.eager_load!
+    super
+    NameDrop::Resources.eager_load!
+  end
 end
+
+require 'name_drop/railtie' if defined?(Rails)

--- a/lib/name_drop/associations/belongs_to.rb
+++ b/lib/name_drop/associations/belongs_to.rb
@@ -21,11 +21,7 @@ module NameDrop
           attr_writer :#{parent}
 
           def #{parent}
-            unless instance_variable_defined?("@#{parent}")
-              @#{parent}= ::NameDrop.resource_class(#{parent}).find(client, attributes[#{key}])
-            end
-
-            @#{parent}
+            @#{parent}||= ::NameDrop.resource_class(#{parent}).find(client, attributes[#{key}])
           end
         EOF
       end

--- a/lib/name_drop/associations/belongs_to.rb
+++ b/lib/name_drop/associations/belongs_to.rb
@@ -1,0 +1,14 @@
+module NameDrop
+  module Associations
+    class BelongsTo
+      def self.relationships
+        @_relationships ||= {}
+      end
+
+      def self.define_relation(parent, child)
+        relationships[child] ||= []
+        relationships[child].push(parent)
+      end
+    end
+  end
+end

--- a/lib/name_drop/associations/belongs_to.rb
+++ b/lib/name_drop/associations/belongs_to.rb
@@ -6,8 +6,28 @@ module NameDrop
       end
 
       def self.define_relation(parent, child)
-        relationships[child] ||= []
-        relationships[child].push(parent)
+        relationships[child.name] ||= []
+        relationships[child.name].push(parent)
+
+        key = "#{parent}_id"
+
+        child.class_eval <<-EOF, __FILE__, __LINE__
+          def #{key}
+            attributes[#{key}]
+          end
+        EOF
+
+        child.class_eval <<-EOF, __FILE__, __LINE__
+          attr_writer :#{parent}
+
+          def #{parent}
+            unless instance_variable_defined?("@#{parent}")
+              @#{parent}= ::NameDrop.resource_class(#{parent}).find(client, attributes[#{key}])
+            end
+
+            @#{parent}
+          end
+        EOF
       end
     end
   end

--- a/lib/name_drop/associations/belongs_to.rb
+++ b/lib/name_drop/associations/belongs_to.rb
@@ -21,7 +21,7 @@ module NameDrop
           attr_writer :#{parent}
 
           def #{parent}
-            @#{parent}||= ::NameDrop.resource_class(#{parent}).find(client, attributes[#{key}])
+            @#{parent}||= ::NameDrop::Resources::#{parent.to_s.classify}.find(client, attributes[#{key}])
           end
         EOF
       end

--- a/lib/name_drop/associations/dsl.rb
+++ b/lib/name_drop/associations/dsl.rb
@@ -5,30 +5,11 @@ module NameDrop
 
       module ClassMethods
         def has_many(collection, options = {})
-          class_name = options[:class_name] || "::NameDrop::Resources::#{collection.to_s.classify}"
-          self_key = "#{self.name.demodulize.downcase}_id".to_sym
-
-          define_method collection do
-            class_name.constantize.all(client, self_key => attributes["id"])
-          end
+          HasMany.define_relation(self, collection, options)
         end
 
         def belongs_to(parent)
           BelongsTo.define_relation(parent, self)
-
-          key = "#{parent}_id"
-
-          define_method key do
-            attributes[key]
-          end
-
-          define_method parent do
-            unless instance_variable_defined?("@_#{parent}")
-              instance_variable_set("@_#{parent}", ::NameDrop.resource_class(parent).find(client, attributes[key]))
-            end
-
-            instance_variable_get("@_#{parent}")
-          end
         end
       end
     end

--- a/lib/name_drop/associations/dsl.rb
+++ b/lib/name_drop/associations/dsl.rb
@@ -1,0 +1,36 @@
+module NameDrop
+  module Associations
+    module Dsl
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def has_many(collection, options = {})
+          class_name = options[:class_name] || "::NameDrop::Resources::#{collection.to_s.classify}"
+          self_key = "#{self.name.demodulize.downcase}_id".to_sym
+
+          define_method collection do
+            class_name.constantize.all(client, self_key => attributes["id"])
+          end
+        end
+
+        def belongs_to(parent)
+          BelongsTo.define_relation(parent, self)
+
+          key = "#{parent}_id"
+
+          define_method key do
+            attributes[key]
+          end
+
+          define_method parent do
+            unless instance_variable_defined?("@_#{parent}")
+              instance_variable_set("@_#{parent}", ::NameDrop.resource_class(parent).find(client, attributes[key]))
+            end
+
+            instance_variable_get("@_#{parent}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/name_drop/associations/has_many.rb
+++ b/lib/name_drop/associations/has_many.rb
@@ -6,7 +6,7 @@ module NameDrop
 
         parent.class_eval <<-EOF, __FILE__, __LINE__
           def #{collection}
-            @#{collection} ||= HasManyProxy.new(self, #{class_name}).all
+            @#{collection} ||= HasManyProxy.new(self, #{class_name})
           end
         EOF
       end

--- a/lib/name_drop/associations/has_many.rb
+++ b/lib/name_drop/associations/has_many.rb
@@ -1,0 +1,15 @@
+module NameDrop
+  module Associations
+    class HasMany
+      def self.define_relation(parent, collection, options = {})
+        class_name = options[:class_name] || "::NameDrop::Resources::#{collection.to_s.classify}"
+
+        parent.class_eval <<-EOF, __FILE__, __LINE__
+          def #{collection}
+            @#{collection} ||= HasManyProxy.new(self, #{class_name}).all
+          end
+        EOF
+      end
+    end
+  end
+end

--- a/lib/name_drop/associations/has_many_proxy.rb
+++ b/lib/name_drop/associations/has_many_proxy.rb
@@ -1,0 +1,29 @@
+module NameDrop
+  module Associations
+    class HasManyProxy
+      def initialize(parent, target_class, collection = [])
+        @parent = parent
+        @target_class = target_class
+        @collection = collection
+      end
+
+      def all
+        target_class.all(parent.client, parent_key => parent.attributes["id"]).each do |child|
+          child.send("#{parent_attribute_name}=", parent) if child.respond_to?("#{parent_attribute_name}=")
+        end
+      end
+
+      private
+
+      attr_reader :parent, :target_class, :collection
+
+      def parent_key
+        [parent_attribute_name, "id"].join("_").to_sym
+      end
+
+      def parent_attribute_name
+        parent.class.name.demodulize.downcase
+      end
+    end
+  end
+end

--- a/lib/name_drop/associations/has_many_proxy.rb
+++ b/lib/name_drop/associations/has_many_proxy.rb
@@ -1,15 +1,39 @@
 module NameDrop
   module Associations
     class HasManyProxy
-      def initialize(parent, target_class, collection = [])
+      def initialize(parent, target_class)
         @parent = parent
         @target_class = target_class
-        @collection = collection
       end
 
       def all
-        target_class.all(parent.client, parent_key => parent.attributes["id"]).each do |child|
+        @all ||= target_class.all(parent.client, parent_key => parent.attributes["id"]).each do |child|
           child.send("#{parent_attribute_name}=", parent) if child.respond_to?("#{parent_attribute_name}=")
+        end
+      end
+
+      def build(attributes = {})
+        target_class.new(parent.client, attributes.merge(parent_key => parent.attributes["id"]))
+      end
+
+      def reload
+        @all = nil
+        all
+      end
+
+      def method_missing(method, *args, &block)
+        if all.respond_to?(method)
+          all.send(method, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method, *args, &block)
+        if all.respond_to?(method)
+          true
+        else
+          super
         end
       end
 

--- a/lib/name_drop/client.rb
+++ b/lib/name_drop/client.rb
@@ -8,7 +8,7 @@ module NameDrop
   #
   # @since 0.1.0
   class Client
-    BASE_URL = "https://web.mention.net/api/accounts"
+    BASE_URL = "https://web.mention.net/api/accounts".freeze
 
     # @!group Resources
 

--- a/lib/name_drop/client.rb
+++ b/lib/name_drop/client.rb
@@ -2,8 +2,7 @@ require 'rest-client'
 
 module NameDrop
   class Client
-    def initialize(*)
-    end
+    BASE_URL = "https://web.mention.net/api/accounts"
 
     def alerts
       Resources::BaseFactory.new(self, 'Alert')
@@ -63,7 +62,11 @@ module NameDrop
     end
 
     def request_url(endpoint)
-      "https://web.mention.net/api/accounts/#{NameDrop.configuration.account_id}/#{endpoint}"
+      [
+        BASE_URL,
+        NameDrop.configuration.account_id,
+        endpoint
+      ].join("/")
     end
   end
 end

--- a/lib/name_drop/configuration.rb
+++ b/lib/name_drop/configuration.rb
@@ -7,19 +7,4 @@ module NameDrop
       @access_token = 'NotARealAccessToken'
     end
   end
-
-  class << self
-
-    def configuration
-      @configuration ||= Configuration.new
-    end
-
-    def configuration=(config)
-      @configuration = config
-    end
-
-    def configure
-      yield(configuration)
-    end
-  end
 end

--- a/lib/name_drop/configuration.rb
+++ b/lib/name_drop/configuration.rb
@@ -7,18 +7,4 @@ module NameDrop
       @access_token = 'NotARealAccessToken'
     end
   end
-
-  class << self
-    def configuration
-      @configuration ||= Configuration.new
-    end
-
-    def configuration=(config)
-      @configuration = config
-    end
-
-    def configure
-      yield(configuration)
-    end
-  end
 end

--- a/lib/name_drop/railtie.rb
+++ b/lib/name_drop/railtie.rb
@@ -1,0 +1,7 @@
+require 'rails/railtie'
+
+module NameDrop
+  class Railtie < Rails::Railtie
+    config.eager_load_namespaces << NameDrop
+  end
+end

--- a/lib/name_drop/resources/alert.rb
+++ b/lib/name_drop/resources/alert.rb
@@ -7,14 +7,6 @@ module NameDrop
       def destroy
         raise NotImplementedError, 'You cannot delete an Alert directly'
       end
-
-      def endpoint
-        self.class.endpoint
-      end
-
-      def self.endpoint(_params = {})
-        'alerts'
-      end
     end
   end
 end

--- a/lib/name_drop/resources/alert.rb
+++ b/lib/name_drop/resources/alert.rb
@@ -17,22 +17,6 @@ module NameDrop
       def destroy
         raise NotImplementedError, 'You cannot delete an Alert directly'
       end
-
-      # Sets suffix of Mention API call
-      #
-      # @see NameDrop::Resources::Alert.endpoint
-      # @return [String] 'alerts'
-      def endpoint
-        self.class.endpoint
-      end
-
-      # Sets suffix of Mention API call
-      #
-      # @param [Hash] _params (unused) for Alerts inherited from Base
-      # @return [String] 'alerts'
-      def self.endpoint(_params = {})
-        'alerts'
-      end
     end
   end
 end

--- a/lib/name_drop/resources/alert.rb
+++ b/lib/name_drop/resources/alert.rb
@@ -1,6 +1,9 @@
 module NameDrop
   module Resources
     class Alert < Base
+      has_many :mentions
+      has_many :shares
+
       def destroy
         raise NotImplementedError, 'You cannot delete an Alert directly'
       end

--- a/lib/name_drop/resources/base.rb
+++ b/lib/name_drop/resources/base.rb
@@ -4,7 +4,7 @@ module NameDrop
       include ::NameDrop::Associations::Dsl
 
       attr_accessor :attributes
-      attr_reader :errors
+      attr_reader :client, :errors
 
       def initialize(client, attributes = {})
         @client = client
@@ -19,8 +19,8 @@ module NameDrop
         end
       end
 
-      def self.find(client, id)
-        response = client.get("#{endpoint}/#{id}")
+      def self.find(client, id, parmas = {})
+        response = client.get("#{endpoint(params)}/#{id}")
         if response[response_key].present?
           new(client, response[response_key])
         else
@@ -53,8 +53,6 @@ module NameDrop
       end
 
       private
-
-      attr_reader :client
 
       def response_key
         self.class.response_key

--- a/lib/name_drop/resources/base.rb
+++ b/lib/name_drop/resources/base.rb
@@ -1,6 +1,8 @@
 module NameDrop
   module Resources
     class Base
+      include ::NameDrop::Associations::Dsl
+
       attr_accessor :attributes
       attr_reader :errors
 

--- a/lib/name_drop/resources/base.rb
+++ b/lib/name_drop/resources/base.rb
@@ -13,14 +13,15 @@ module NameDrop
       end
 
       def self.all(client, params = {})
-        response = client.get(endpoint(params))
+        response = client.get(path(params: params))
         response[response_key.pluralize].map do |attributes|
           new(client, attributes)
         end
       end
 
       def self.find(client, id, parmas = {})
-        response = client.get("#{endpoint(params)}/#{id}")
+        response = client.get(path(type: :singular, params: { id: id }))
+
         if response[response_key].present?
           new(client, response[response_key])
         else
@@ -28,13 +29,53 @@ module NameDrop
         end
       end
 
+      def self.build_nested_prefix(attributes)
+        attributes = attributes.with_indifferent_access
+        belongs_to_relationships = ::NameDrop::Associations::BelongsTo.relationships[self.name]
+        prefix = ""
+        return prefix unless belongs_to_relationships.present?
+
+        belongs_to_relationships.inject(prefix) { |pref_so_far, rel|
+          pref_so_far.to_s + rel.to_s.pluralize + "/" + attributes["#{rel}_id"].to_s + "/"
+        }
+      end
+
+      def self.path(params: {}, type: nil, prefix: nil, new_record: false)
+        params = params.with_indifferent_access
+
+        prefix = prefix || build_nested_prefix(params)
+        resource_name = self.name.demodulize.downcase.pluralize
+        endpoint = prefix + resource_name
+
+        if type == :singular
+          endpoint + params["id"]
+        elsif type == :persistence
+          if new_record
+            endpoint
+          else
+            endpoint + "/" + params["id"]
+          end
+        else
+          endpoint
+        end
+      end
+
+      def path(type:)
+        self.class.path(
+          type: type,
+          params: attributes,
+          prefix: self.class.build_nested_prefix(attributes),
+          new_record: new_record?
+        )
+      end
+
       def self.build(client, attributes = {})
         new(client, attributes)
       end
 
       def save
-        path = new_record? ? endpoint : "#{endpoint}/#{attributes[:id]}"
-        response = client.send(persistence_action, path, attributes)
+        response = client.send(persistence_action, path(type: :persistence), attributes)
+
         if response[response_key].present?
           self.attributes = response[response_key]
           true
@@ -45,7 +86,7 @@ module NameDrop
       end
 
       def destroy(params = {})
-        client.delete("#{endpoint(params)}/#{attributes[:id]}")
+        client.delete(path(type: :singular))
       end
 
       def self.response_key

--- a/lib/name_drop/resources/base.rb
+++ b/lib/name_drop/resources/base.rb
@@ -73,7 +73,7 @@ module NameDrop
         return prefix unless belongs_to_relationships.present?
 
         belongs_to_relationships.inject(prefix) { |pref_so_far, rel|
-          pref_so_far.to_s + rel.to_s.pluralize + "/" + attributes["#{rel}_id"].to_s + "/"
+          "#{pref_so_far}#{rel.to_s.pluralize}/#{attributes["#{rel}_id"]}/"
         }
       end
 
@@ -81,16 +81,16 @@ module NameDrop
         params = params.with_indifferent_access
 
         prefix = prefix || build_nested_prefix(params)
-        resource_name = self.name.demodulize.downcase.pluralize
+        resource_name = self.name.demodulize.underscore.pluralize
         endpoint = prefix + resource_name
 
         if type == :singular
-          endpoint + params["id"]
+          "#{endpoint}/#{params["id"]}"
         elsif type == :persistence
           if new_record
             endpoint
           else
-            endpoint + "/" + params["id"]
+            "#{endpoint}/#{params["id"]}"
           end
         else
           endpoint

--- a/lib/name_drop/resources/mention.rb
+++ b/lib/name_drop/resources/mention.rb
@@ -14,14 +14,6 @@ module NameDrop
       def destroy
         raise NotImplementedError, 'You cannot alter a mention'
       end
-
-      def endpoint
-        self.class.endpoint(alert_id: alert_id)
-      end
-
-      def self.endpoint(params = {})
-        "alerts/#{params[:alert_id]}/mentions"
-      end
     end
   end
 end

--- a/lib/name_drop/resources/mention.rb
+++ b/lib/name_drop/resources/mention.rb
@@ -1,6 +1,8 @@
 module NameDrop
   module Resources
     class Mention < Base
+      belongs_to :alert
+
       def self.find(_id)
         raise NotImplementedError, 'Single fetch mention not supported'
       end
@@ -11,6 +13,10 @@ module NameDrop
 
       def destroy
         raise NotImplementedError, 'You cannot alter a mention'
+      end
+
+      def endpoint
+        self.class.endpoint(alert_id: alert_id)
       end
 
       def self.endpoint(params = {})

--- a/lib/name_drop/resources/share.rb
+++ b/lib/name_drop/resources/share.rb
@@ -1,6 +1,8 @@
 module NameDrop
   module Resources
     class Share < Base
+      belongs_to :alert
+
       def self.find(_id)
         raise NotImplementedError, 'Single fetch share not supported'
       end

--- a/lib/name_drop/resources/share.rb
+++ b/lib/name_drop/resources/share.rb
@@ -10,14 +10,6 @@ module NameDrop
       def save
         raise NotImplementedError, 'Single fetch update not supported'
       end
-
-      def self.endpoint(params = {})
-        "alerts/#{params[:alert_id]}/shares"
-      end
-
-      def endpoint(params = {})
-        self.class.endpoint(params)
-      end
     end
   end
 end

--- a/spec/name_drop/associations/belongs_to_spec.rb
+++ b/spec/name_drop/associations/belongs_to_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+describe NameDrop::Associations::BelongsTo do
+  NameDrop::Resources::Parent = Class.new(NameDrop::Resources::Base)
+  NameDrop::Resources::Child = Class.new(NameDrop::Resources::Base)
+
+  before do
+    described_class.define_relation(:parent, NameDrop::Resources::Child)
+  end
+
+  describe "getting the parent ID" do
+    it "defines a method" do
+      expect(NameDrop::Resources::Child.instance_methods).to include(:parent)
+    end
+  end
+
+  describe "getting the parent object" do
+    it "defines a method" do
+      expect(NameDrop::Resources::Child.instance_methods).to include(:parent_id)
+    end
+  end
+
+  describe "setting the parent object" do
+    it "defines a setter" do
+      expect(NameDrop::Resources::Child.instance_methods).to include(:parent=)
+    end
+  end
+end

--- a/spec/name_drop/associations/dsl_spec.rb
+++ b/spec/name_drop/associations/dsl_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe NameDrop::Associations::Dsl do
+  class BaseClass
+    include NameDrop::Associations::Dsl
+  end
+
+  describe "when included into another class" do
+    describe ".has_many" do
+      it "defines a has_many relation" do
+        expect(NameDrop::Associations::HasMany).to receive(:define_relation).with(BaseClass, :child_records, {})
+        BaseClass.has_many(:child_records)
+      end
+    end
+
+    describe ".belongs_to" do
+      it "defines a belongs_to relation" do
+        expect(NameDrop::Associations::BelongsTo).to receive(:define_relation).with(:parent, BaseClass)
+        BaseClass.belongs_to(:parent)
+      end
+    end
+  end
+end

--- a/spec/name_drop/associations/has_many_proxy_spec.rb
+++ b/spec/name_drop/associations/has_many_proxy_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+describe NameDrop::Associations::HasManyProxy do
+  Target = Class.new(NameDrop::Resources::Base)
+
+  subject { described_class.new(parent, target_class) }
+  let(:target_class) { Target }
+  let(:parent) { double("parent") }
+  let(:client) { double("client") }
+
+  before do
+    allow(parent).to receive(:client).and_return(client)
+    allow(parent).to receive(:attributes).and_return("id" => "123")
+  end
+
+  it "has a target class" do
+    expect(subject.instance_values).to include("target_class" => target_class)
+  end
+  it "has a parent" do
+    expect(subject.instance_values).to include("parent" => parent)
+  end
+
+  context "delegating to the target class" do
+    it "fetches a collection" do
+      expect(target_class).to receive(:all).with(client, double_id: "123").and_return([])
+      subject.all
+    end
+
+    context "building a new instance" do
+      let(:attributes) { { name: "Some Name" } }
+
+      it "builds the instance with attributes, including the parent ID" do
+        expect(target_class).to receive(:new).with(client, attributes.merge(double_id: "123"))
+        subject.build(attributes)
+      end
+    end
+  end
+
+  it "reloads the collection" do
+    expect(subject).to receive(:all).once.and_return(true)
+    subject.reload
+  end
+
+  it "delegates missing methods to the collection" do
+    allow(target_class).to receive(:all).and_return([])
+    expect(subject.all).to receive(:each)
+    subject.each
+  end
+end

--- a/spec/name_drop/associations/has_many_spec.rb
+++ b/spec/name_drop/associations/has_many_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe NameDrop::Associations::HasMany do
+  NameDrop::Resources::ParentClass = Class.new(NameDrop::Resources::Base)
+  NameDrop::Resources::Child = Class.new(NameDrop::Resources::Base)
+
+  before do
+    described_class.define_relation(NameDrop::Resources::ParentClass, :children)
+  end
+
+  it "defines a method that corresponds to the association name" do
+    expect(NameDrop::Resources::ParentClass.instance_methods).to include(:children)
+  end
+
+  it "memoizes the result" do
+    instance = NameDrop::Resources::ParentClass.new(anything)
+    expect(instance.instance_values.keys).to_not include("children")
+    instance.children
+    expect(instance.instance_values.keys).to include("children")
+  end
+end

--- a/spec/name_drop/resources/alert_spec.rb
+++ b/spec/name_drop/resources/alert_spec.rb
@@ -125,16 +125,4 @@ describe NameDrop::Resources::Alert do
       }.to raise_error(NotImplementedError)
     end
   end
-
-  describe '.endpoint' do
-    it 'returns alerts' do
-      expect(NameDrop::Resources::Alert.endpoint).to eq('alerts')
-    end
-  end
-
-  describe '#endpoint' do
-    it 'returns alerts' do
-      expect(alert.endpoint).to eq('alerts')
-    end
-  end
 end

--- a/spec/name_drop/resources/base_spec.rb
+++ b/spec/name_drop/resources/base_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+describe NameDrop::Resources::Base do
+  let(:parent_class_id) { 1 }
+  let(:belongs_to_class_id) { 2 }
+
+  describe ".path" do
+    context "when the resource belongs to another resource" do
+      class ParentClass < NameDrop::Resources::Base
+
+      end
+
+      class BelongsToClass < NameDrop::Resources::Base
+        belongs_to :parent_class
+      end
+
+      it "constructs the url with the parent association as a prefix" do
+        expect(BelongsToClass.path(params: { parent_class_id: parent_class_id })).to eq "parent_classes/#{parent_class_id}/belongs_to_classes"
+      end
+    end
+
+    context "when the action is singular" do
+      it "appends the resource ID to the path" do
+        expect(ParentClass.path(type: :singular, params: { id: parent_class_id })).to eq "parent_classes/#{parent_class_id}"
+      end
+    end
+
+    context "when the action is for a collection" do
+      it "returns the collection path" do
+        expect(ParentClass.path).to eq "parent_classes"
+      end
+    end
+
+    context "when the action is persistence" do
+      it "appends the resource ID to the path" do
+        expect(ParentClass.path(type: :persistence, params: { id: parent_class_id })).to eq "parent_classes/#{parent_class_id}"
+      end
+    end
+  end
+
+  describe "#path" do
+    subject { BelongsToClass.new(anything, id: belongs_to_class_id, parent_class_id: parent_class_id) }
+
+    it "generates the path based on the instance attributes" do
+      expect(subject.path(type: :singular)).to eq "parent_classes/#{parent_class_id}/belongs_to_classes/#{belongs_to_class_id}"
+    end
+  end
+end

--- a/spec/name_drop/resources/mention_spec.rb
+++ b/spec/name_drop/resources/mention_spec.rb
@@ -34,10 +34,4 @@ describe NameDrop::Resources::Mention do
       }.to raise_error(NotImplementedError)
     end
   end
-
-  describe '.endpoint' do
-    it 'returns alerts/:alert_id/mentions' do
-      expect(NameDrop::Resources::Mention.endpoint(alert_id: 1)).to eq('alerts/1/mentions')
-    end
-  end
 end

--- a/spec/name_drop/resources/share_spec.rb
+++ b/spec/name_drop/resources/share_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe NameDrop::Resources::Share do
   let(:client) { NameDrop::Client.new }
-  let(:share) { NameDrop::Resources::Share.new(client, 'id' => 8) }
+  let(:share) { NameDrop::Resources::Share.new(client, 'id' => 8, 'alert_id' => 5) }
 
   describe '#all' do
     it 'calls get on client' do
@@ -30,19 +30,7 @@ describe NameDrop::Resources::Share do
   describe '#destroy' do
     it 'sends client delete with appropriate endpoint' do
       expect(client).to receive(:delete).with('alerts/5/shares/8')
-      share.destroy(alert_id: 5)
-    end
-  end
-
-  describe '.endpoint' do
-    it 'returns alerts/:alert_id/shares' do
-      expect(NameDrop::Resources::Share.endpoint(alert_id: 2)).to eq('alerts/2/shares')
-    end
-  end
-
-  describe '#endpoint' do
-    it 'returns alerts/:alert_id/shares' do
-      expect(share.endpoint(alert_id: 3)).to eq('alerts/3/shares')
+      share.destroy
     end
   end
 end


### PR DESCRIPTION
This introduces the concept of associations to NameDrop resources to establish relationships between models that mimics the resourceful routing of the Mention API.

In addition to providing a nice syntax for building and accessing associated records, it provides a way of constructing URLs based on `belongs_to` associations.

Notes:
- Opening this PR early to get feedback
- ~~Should be merged after #22~~

To Do:
- [x] Tests for the association behaviour and dynamic URL building
- [ ] Yard doc for new methods
- [x] Update Readme with usage instructions
- [ ] Chains of `belongs_to` associations greater than 1
