### PR TITLE
Add params to URL instead of body for GET requests

### DIFF
--- a/lib/name_drop/client.rb
+++ b/lib/name_drop/client.rb
@@ -82,8 +82,18 @@ module NameDrop
     private
 
     def build_request(endpoint, method, attributes = {})
-      request = "Net::HTTP::#{method}".constantize.new request_uri(endpoint)
-      request.body = JSON.dump(attributes) if attributes.any?
+      uri = request_uri(endpoint)
+
+      if method == 'Get'
+        uri.query = URI.encode_www_form(attributes)
+      end
+
+      request = "Net::HTTP::#{method}".constantize.new uri
+
+      unless method == 'Get'
+        request.body = JSON.dump(attributes) if attributes.any?
+      end
+
       request
     end
 

--- a/lib/name_drop/client.rb
+++ b/lib/name_drop/client.rb
@@ -57,7 +57,7 @@ module NameDrop
     # @param [Hash] attributes
     # @return [Hash] encapsulates Mention API response of POST request
     def post(endpoint, attributes)
-      execute_request build_request(endpoint, 'Post', attributes)
+      execute_request build_request_with_body(endpoint, 'Post', attributes)
     end
 
     # Makes PUT Request through RestClient::Request.execute
@@ -66,7 +66,7 @@ module NameDrop
     # @param [Hash] attributes
     # @return [Hash] encapsulates Mention API response of PUT request
     def put(endpoint, attributes)
-      execute_request build_request(endpoint, 'Put', attributes)
+      execute_request build_request_with_body(endpoint, 'Put', attributes)
     end
 
     # Makes DELETE Request through RestClient::Request.execute
@@ -83,17 +83,13 @@ module NameDrop
 
     def build_request(endpoint, method, attributes = {})
       uri = request_uri(endpoint)
+      uri.query = URI.encode_www_form(attributes) if attributes.present?
+      "Net::HTTP::#{method}".constantize.new uri
+    end
 
-      if method == 'Get'
-        uri.query = URI.encode_www_form(attributes)
-      end
-
-      request = "Net::HTTP::#{method}".constantize.new uri
-
-      unless method == 'Get'
-        request.body = JSON.dump(attributes) if attributes.any?
-      end
-
+    def build_request_with_body(endpoint, method, attributes = {})
+      request = "Net::HTTP::#{method}".constantize.new request_uri(endpoint)
+      request.body = JSON.dump(attributes) if attributes.any?
       request
     end
 

--- a/spec/name_drop/client_spec.rb
+++ b/spec/name_drop/client_spec.rb
@@ -72,8 +72,15 @@ describe NameDrop::Client do
     let(:endpoint) { 'alerts' }
     let(:arguments) { [endpoint] }
     let(:attributes) { { your_mom: "can't miss" } }
+    let(:url) { base_url.join("alerts?your_mom=can't%20miss").to_s }
+
+    it 'should serialize the params and append them to the URL' do
+      stub_request(method, url).with(headers: headers).to_return(status: 200, body: 'null', headers: {})
+      client.send(method, endpoint, attributes)
+      assert_requested(method, url, headers: headers)
+    end
+
     it_should_behave_like 'a request'
-    it_should_behave_like 'a request with attributes'
   end
 
   describe '#post' do


### PR DESCRIPTION
GET requests do not support attributes in the body of the request. Instead they belong in the URL as query params. This makes precisely that change.
