### PR TITLE
Add -verbose- option to configuration to enable verbose logging

### DIFF
--- a/lib/name_drop/configuration.rb
+++ b/lib/name_drop/configuration.rb
@@ -10,7 +10,7 @@ module NameDrop
     #   @return [String] Mention Account ID
     # @!attribute access_token
     #   @return [String] Mention Application Access Token
-    attr_accessor :account_id, :access_token
+    attr_accessor :account_id, :access_token, :verbose
 
     # Initializes new NameDrop::Configuration object
     #
@@ -18,6 +18,7 @@ module NameDrop
     def initialize
       @account_id = 'NotARealAccountID'
       @access_token = 'NotARealAccessToken'
+      @verbose = false
     end
   end
 end

--- a/lib/name_drop/error.rb
+++ b/lib/name_drop/error.rb
@@ -20,5 +20,11 @@ module NameDrop
       @detail = detail
       super msg
     end
+
+    def to_s
+      super.tap { |s| s << "\n#{detail}" if NameDrop.configuration.verbose }
+    end
+
+    alias inspect to_s
   end
 end

--- a/lib/name_drop/resources/base.rb
+++ b/lib/name_drop/resources/base.rb
@@ -103,6 +103,20 @@ module NameDrop
         name.demodulize.downcase
       end
 
+      # Determines whether object is a new_record, which is true if :id key is missing
+      #
+      # @return [Boolean]
+      def new_record?
+        !attributes[:id]
+      end
+
+      # Determines whether object is persisted, which is true if :id key is present
+      #
+      # @return [Boolean]
+      def persisted?
+        !!attributes[:id]
+      end
+
       private
 
       # @!attribute [r] client
@@ -122,13 +136,6 @@ module NameDrop
       # @return [Symbol]
       def persistence_action
         new_record? ? :post : :put
-      end
-
-      # Determines whether object is a new_record, which is true if :id key is missing
-      #
-      # @return [Boolean]
-      def new_record?
-        !attributes[:id]
       end
     end
   end

--- a/spec/name_drop/error_spec.rb
+++ b/spec/name_drop/error_spec.rb
@@ -1,16 +1,31 @@
 require 'spec_helper'
 
 describe NameDrop::Error do
+  subject(:error) { described_class.new("These aren't the", 'Droids were looking for') }
+
   describe '#initialize' do
     it 'sets the message' do
-      error = NameDrop::Error.new('These arent the', 'Droids were looking for')
-      expect(error.message).to eq('These arent the')
+      expect(error.message).to eq("These aren't the")
     end
 
-    it 'sets the detail
-' do
-      error = NameDrop::Error.new('You will take me', 'to Jobba now')
+    it 'sets the detail' do
+      error = described_class.new('You will take me', 'to Jobba now')
       expect(error.detail).to eq('to Jobba now')
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns the message for the exception' do
+      expect(subject.to_s).to eq "These aren't the"
+    end
+
+    context 'when -verbose- configuration option is enabled' do
+      before(:each) { NameDrop.configuration.verbose = true }
+      after(:each) { NameDrop.configuration.verbose = false }
+
+      it 'returns the message and detail for the exception' do
+        expect(subject.to_s).to eq "These aren't the\nDroids were looking for"
+      end
     end
   end
 end

--- a/spec/name_drop/resources/alert_spec.rb
+++ b/spec/name_drop/resources/alert_spec.rb
@@ -2,34 +2,34 @@ require 'spec_helper'
 
 describe NameDrop::Resources::Alert do
   let(:client) { NameDrop::Client.new }
-  let(:alert) { NameDrop::Resources::Alert.new(client) }
+  
+  subject(:alert) { described_class.new(client) }
 
   describe '#all' do
     it 'calls get on client' do
       expect(client).to receive(:get).with('alerts', {}).and_return('alerts' => [{ 'a' => 'b' }, { 'c' => 'd' }])
-      NameDrop::Resources::Alert.all(client)
+      described_class.all(client)
     end
   end
-
 
   describe '#find' do
     it 'calls get on client' do
       expect(client).to receive(:get).with('alerts/8').and_return('alert' => { 'a' => 'b' })
-      NameDrop::Resources::Alert.find(client, 8)
+      described_class.find(client, 8)
     end
 
     context 'response_key found in reply' do
       it 'return an alert record' do
         allow(client).to receive(:get).with('alerts/8').and_return('alert' => { 'a' => 'b' })
-        result = NameDrop::Resources::Alert.find(client, 8)
-        expect(result.class).to eq(NameDrop::Resources::Alert)
+        result = described_class.find(client, 8)
+        expect(result.class).to eq(described_class)
       end
     end
 
     context 'response_key not found in reply' do
       it 'return response not an alert record' do
         allow(client).to receive(:get).with('alerts/8').and_return('siren' => { 'a' => 'b' })
-        result = NameDrop::Resources::Alert.find(client, 8)
+        result = described_class.find(client, 8)
         expect(result.class).to eq(Hash)
       end
     end
@@ -37,8 +37,8 @@ describe NameDrop::Resources::Alert do
 
   describe '#build' do
     it 'returns a new record' do
-      alert = NameDrop::Resources::Alert.build(client, { 'hmm' => 'there' })
-      expect(alert.class).to eq(NameDrop::Resources::Alert)
+      alert = described_class.build(client, { 'hmm' => 'there' })
+      expect(alert.class).to eq(described_class)
     end
   end
 
@@ -103,7 +103,7 @@ describe NameDrop::Resources::Alert do
       let(:action) { :post }
       let(:end_point) { 'alerts' }
       let(:attr) { { whoa: 'neo' } }
-      let(:alert) { NameDrop::Resources::Alert.build(client, attr) }
+      let(:alert) { described_class.build(client, attr) }
 
       it_should_behave_like '#save'
     end
@@ -112,7 +112,7 @@ describe NameDrop::Resources::Alert do
       let(:action) { :put }
       let(:end_point) { 'alerts/8' }
       let(:attr) { { 'id' => '8', 'hmm' => 'there' } }
-      let(:alert) { NameDrop::Resources::Alert.build(client, attr) }
+      let(:alert) { described_class.build(client, attr) }
 
       it_should_behave_like '#save'
     end
@@ -128,13 +128,49 @@ describe NameDrop::Resources::Alert do
 
   describe '.endpoint' do
     it 'returns alerts' do
-      expect(NameDrop::Resources::Alert.endpoint).to eq('alerts')
+      expect(described_class.endpoint).to eq('alerts')
     end
   end
 
   describe '#endpoint' do
     it 'returns alerts' do
       expect(alert.endpoint).to eq('alerts')
+    end
+  end
+  
+  describe '#new_record?' do
+    context 'when the record is a new record' do
+      before(:each) { subject.attributes[:id] = nil }
+      
+      it 'returns true' do
+        expect(subject.new_record?).to eq true
+      end
+    end
+    
+    context 'when the record is not a new record' do
+      before(:each) { subject.attributes[:id] = 101 }
+      
+      it 'returns false' do
+        expect(subject.new_record?).to eq false
+      end
+    end
+  end
+  
+  describe '#persisted?' do
+    context 'when the record is a new record' do
+      before(:each) { subject.attributes[:id] = nil }
+      
+      it 'returns false' do
+        expect(subject.persisted?).to eq false
+      end
+    end
+    
+    context 'when the record is not a new record' do
+      before(:each) { subject.attributes[:id] = 101 }
+      
+      it 'returns true' do
+        expect(subject.persisted?).to eq true
+      end
     end
   end
 end


### PR DESCRIPTION
Found this to be invaluable when working with mention API

### Changes
* New config option `NameDrop.configuration.verbose` to include the `@detail` in error messages
* Make `Alert#new_record?` public
* Add `Alert#persisted?` to compliment `new_record?`

### Open Questions
* Should this be the default setting?