### PR TITLE
Add `children` to Mention resource to retrieve child mentions

### DIFF
--- a/lib/name_drop/resources/mention.rb
+++ b/lib/name_drop/resources/mention.rb
@@ -26,6 +26,9 @@ module NameDrop
         raise NotImplementedError, 'You cannot alter a mention'
       end
 
+      # @note The default page size for children is 20, although up to 100 can be returned
+      #   by specifying limit: 100. The Mention API also returns paging data so we can support
+      #   pagination in the future if the need arises.
       # @return [Array] Collection of child mentions
       def children(params = {})
         endpoint = "#{self.class.endpoint(alert_id: attributes[:alert_id])}/#{attributes[:id]}/children"

--- a/lib/name_drop/resources/mention.rb
+++ b/lib/name_drop/resources/mention.rb
@@ -26,6 +26,16 @@ module NameDrop
         raise NotImplementedError, 'You cannot alter a mention'
       end
 
+      # @return [Array] Collection of child mentions
+      def children(params = {})
+        endpoint = "#{self.class.endpoint(alert_id: attributes[:alert_id])}/#{attributes[:id]}/children"
+
+        response = client.get(endpoint, params)
+        response["children"].map do |attributes|
+          self.class.new(client, attributes)
+        end
+      end
+
       # Sets suffix of Mention API call
       #
       # @param [Hash] params the options to return an endpoint with

--- a/spec/name_drop/resources/mention_spec.rb
+++ b/spec/name_drop/resources/mention_spec.rb
@@ -44,6 +44,48 @@ describe NameDrop::Resources::Mention do
     end
   end
 
+  describe '#children' do
+    let(:children_attributes) {
+      {
+        'children' => [
+          {
+            'id' => '9',
+            'alert_id' => '1',
+            'title' => 'i am a child'
+
+          },
+          {
+            'id' => '10',
+            'alert_id' => '1',
+            'title' => 'another child'
+
+          },
+        ]
+      }
+    }
+
+    before do
+      mention.attributes[:id] = '2'
+      mention.attributes[:alert_id] = '1'
+    end
+
+    it 'calls get on client with the correct endpoint and params' do
+      expect(client).to receive(:get).with('alerts/1/mentions/2/children', { limit: 2 }).and_return(children_attributes)
+      mention.children(limit: 2)
+    end
+
+    context 'when there are children' do
+      before do
+        allow(client).to receive(:get).and_return(children_attributes)
+      end
+
+      it 'initializes Mention resource objects for each child' do
+        expect(mention.children.map(&:class).uniq).to eq [NameDrop::Resources::Mention]
+        expect(mention.children.map { |c| c.attributes['title'] }).to match_array ['i am a child', 'another child']
+      end
+    end
+  end
+
   describe '.endpoint' do
     it 'returns alerts/:alert_id/mentions' do
       expect(NameDrop::Resources::Mention.endpoint(alert_id: 1)).to eq('alerts/1/mentions')

--- a/spec/name_drop/resources/mention_spec.rb
+++ b/spec/name_drop/resources/mention_spec.rb
@@ -58,7 +58,6 @@ describe NameDrop::Resources::Mention do
             'id' => '10',
             'alert_id' => '1',
             'title' => 'another child'
-
           },
         ]
       }


### PR DESCRIPTION
Mentions can be nested under a parent. E.g. a Re-Tweet.

This adds a `children` method to instances of `NameDrop::Resources::Mention` to access the mention's child mentions.

Its worth noting that the default page size for children is 20, although up to 100 can be returned by specifying `limit: 100`. The Mention API also returns paging data so we can support pagination in the future if the need arises.